### PR TITLE
「ものすごく長い日本語のタイトルが付いた記事の表示テスト」を追加

### DIFF
--- a/wordpress-theme-test-date-ja.xml
+++ b/wordpress-theme-test-date-ja.xml
@@ -15057,5 +15057,38 @@ Superscript タグ <code>&lt;sup&gt;</code> を使うと E = MC<sup>2</sup> の�
 			<wp:meta_value><![CDATA[8]]></wp:meta_value>
 		</wp:postmeta>
 	</item>
+	<item>
+		<title>ものすごく長い日本語のタイトルが付いた記事の表示テストです。1行分しか想定されていない見出しのデザインだと文字がはみ出してしまってあら大変。複数行になっても問題ないデザインだといいですね。あと前後の記事へのリンクを出力している場合や、パンくずリストを実装している場合なども表示にズレがないか確認しておきましょう。</title>
+		<link>http://wp03.ozonenotes.jp/archives/78</link>
+		<pubDate>Sun, 05 Jan 2014 06:01:18 +0000</pubDate>
+		<dc:creator><![CDATA[mypacecreator]]></dc:creator>
+		<guid isPermaLink="false">http://wp03.ozonenotes.jp/?p=78</guid>
+		<description></description>
+		<content:encoded><![CDATA[<ul>
+	<li>記事タイトル部分の見出しデザインが崩れていないか、文字が背景からはみ出していたりしないか確認しましょう。</li>
+	<li>previous_post_linkやnext_post_linkなどで前後の記事のタイトルを出力する場合も、レイアウト崩れが発生していないか確認しましょう。</li>
+	<li>その他、ウィジェットやプラグイン等でいろいろな場所に記事タイトルが出力されるケースが多いので併せて確認しましょう。</li>
+	<li>用途に応じて、PHPの<a href="http://www.php.net/manual/ja/function.mb-substr.php" target="_blank">mb_substr</a>や<a href="http://www.php.net/manual/ja/function.mb-strlen.php" target="_blank">mb_strlen</a>関数を使って文字列をトリミングするという手もあります。
+※その際、<a href="http://wpdocs.sourceforge.jp/%E3%83%87%E3%83%BC%E3%82%BF%E6%A4%9C%E8%A8%BC" target="_blank">データの無害化 (サニタイズ) </a>にも配慮するとより盤石です。</li>
+</ul>]]></content:encoded>
+		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
+		<wp:post_id>78</wp:post_id>
+		<wp:post_date>2014-01-05 15:01:18</wp:post_date>
+		<wp:post_date_gmt>2014-01-05 06:01:18</wp:post_date_gmt>
+		<wp:comment_status>closed</wp:comment_status>
+		<wp:ping_status>closed</wp:ping_status>
+		<wp:post_name>%e3%82%82%e3%81%ae%e3%81%99%e3%81%94%e3%81%8f%e9%95%b7%e3%81%84%e6%97%a5%e6%9c%ac%e8%aa%9e%e3%81%ae%e3%82%bf%e3%82%a4%e3%83%88%e3%83%ab%e3%81%8c%e4%bb%98%e3%81%84%e3%81%9f%e8%a8%98%e4%ba%8b%e3%81%ae</wp:post_name>
+		<wp:status>publish</wp:status>
+		<wp:post_parent>0</wp:post_parent>
+		<wp:menu_order>0</wp:menu_order>
+		<wp:post_type>post</wp:post_type>
+		<wp:post_password></wp:post_password>
+		<wp:is_sticky>0</wp:is_sticky>
+		<category domain="category" nicename="%e6%a5%b5%e7%ab%af%e3%81%aa%e4%be%8b"><![CDATA[極端な例]]></category>
+		<wp:postmeta>
+			<wp:meta_key>_edit_last</wp:meta_key>
+			<wp:meta_value><![CDATA[1]]></wp:meta_value>
+		</wp:postmeta>
+	</item>
 </channel>
 </rss>


### PR DESCRIPTION
「タイトルが長い英単語の時」はありますが、日本語の場合がないので作りました。
linkやguidに入るドメインや、autherの部分、投稿日などどうすべきかよく分からなかったので、直したほうが良い所あればご指摘くださいm(_ _)m
