### PR TITLE
「投稿フォーマット: 画像(リンク)」の画像URLが間違っているようです

### DIFF
--- a/wordpress-theme-test-date-ja.xml
+++ b/wordpress-theme-test-date-ja.xml
@@ -1718,7 +1718,7 @@
 		<link>http://kassad-tekapo.sqale.jp/?attachment_id=807</link>
 		<pubDate>Mon, 04 Jun 2012 18:36:56 +0000</pubDate>
 		<dc:creator><![CDATA[themedemos]]></dc:creator>
-		<guid isPermaLink="false">https://wpthemetestdata.files.wordpress.com/2008/06/dsc20040724_152504_532.jpg</guid>
+		<guid isPermaLink="false">https://wpthemetestdata.files.wordpress.com/2012/06/dsc20040724_152504_532.jpg</guid>
 		<description></description>
 		<content:encoded><![CDATA[]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>
@@ -11343,7 +11343,7 @@ Superscript タグ <code>&lt;sup&gt;</code> を使うと E = MC<sup>2</sup> の�
 		<dc:creator><![CDATA[WP-Hangouts]]></dc:creator>
 		<guid isPermaLink="false">http://wpthemetestdata.wordpress.com/?p=568</guid>
 		<description></description>
-		<content:encoded><![CDATA[[caption id="attachment_612" align="aligncenter" width="640" caption="樹脂を含むススキノキの殻のかたまり。西オーストラリア、クラークソン。よく燃える。"]<a href="http://wpthemetestdata.files.wordpress.com/2008/06/dsc20040724_152504_532.jpg"><img src="http://wpthemetestdata.files.wordpress.com/2008/06/dsc20040724_152504_532.jpg" alt="樹脂を含むススキノキの殻のかたまり" title="dsc20040724_152504_532" width="640" height="480" class="size-full wp-image-612" /></a>[/caption]
+		<content:encoded><![CDATA[[caption id="attachment_612" align="aligncenter" width="640" caption="樹脂を含むススキノキの殻のかたまり。西オーストラリア、クラークソン。よく燃える。"]<a href="http://wpthemetestdata.files.wordpress.com/2012/06/dsc20040724_152504_532.jpg"><img src="http://wpthemetestdata.files.wordpress.com/2012/06/dsc20040724_152504_532.jpg" alt="樹脂を含むススキノキの殻のかたまり" title="dsc20040724_152504_532" width="640" height="480" class="size-full wp-image-612" /></a>[/caption]
 
 ]]></content:encoded>
 		<excerpt:encoded><![CDATA[]]></excerpt:encoded>


### PR DESCRIPTION
https://wpthemetestdata.files.wordpress.com 上に、正しいと思われるファイルがありましたので修正しました。